### PR TITLE
Require gzip compression for event submissions

### DIFF
--- a/server/api/events.go
+++ b/server/api/events.go
@@ -94,6 +94,7 @@ func (eventsAPI EventsAPI) Handle(responseWriter http.ResponseWriter, request *h
 	gzipReader, err := gzip.NewReader(request.Body)
 	if err != nil {
 		log.Info().Err(err).Msg("Failed to parse gzip content")
+		responseWriter.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	defer func() {


### PR DESCRIPTION
Perform decompression after auth is done to avoid zip bombs